### PR TITLE
Multinuclides

### DIFF
--- a/adriver/matall_module.f90
+++ b/adriver/matall_module.f90
@@ -18,7 +18,8 @@ module matall
     real, allocatable::    &
         cden(:), ccon(:)        ! cden(i), ccon(i) -- cell density and concentration for cell with index i
 
-    public get_mat_allocation, get_mcnp_names, get_ma_adress
+    public get_mat_allocation, get_mcnp_names, get_ma_adress, get_ma_properties, &
+           get_ma_nom
 
     contains
         subroutine get_mat_allocation()
@@ -104,6 +105,19 @@ module matall
             vol = get_mesh_volume(i, j, k)
             return 
         end subroutine get_ma_properties
+
+        function get_ma_nom(i, j, k) result(nom)
+            ! return number of materials in the fine mesh element i, j, k
+            implicit none
+            integer, intent(in):: i, j, k
+            integer:: nom
+
+            ! local vars
+            integer:: i1, i2
+            call get_ma_adress(i, j, k, i1, i2)
+            nom = count(cmat(ma_ci(i1: i2)) .gt. 0)
+            return 
+        end function get_ma_nom
 
         subroutine p_read_cmi(fname)
             ! Read information from the print table CMI
@@ -244,13 +258,13 @@ module matall
                 do j = 1, nj, dj
                     do k = 1, nk, dk
                         l = ma_3(i, j, k)
-                        write(pr_log, '(4i5, \)') i, j, k, l
+                        write(pr_log, '(3i5, i8, \)') i, j, k, l
                         if (l .gt. 0) then
                             i1 = ma_i(l-1) + 1
                             i2 = ma_i(l)
                             n = i2 - i1 + 1
                             write(pr_log, '(<n>i9)') ma_ci(i1: i2)
-                            write(pr_log, '(20x, <n>i9)') ma_ch(i1: i2)
+                            write(pr_log, '(23x, <n>i9)') ma_ch(i1: i2)
                         else
                             write(pr_log, *)
                         end if

--- a/decaygammasampling.rst
+++ b/decaygammasampling.rst
@@ -68,3 +68,12 @@ The source particle weight ``W_i`` is obtained by inserting (5) and (6) to (3)::
                  =  N sum(S_gi, g=1..G)
                  
                  
+Comparison
+------------
+The original implementation might appear more effective. Consider a mesh element with small material volumetric fraction. In the original implementation, when the chosen coordinate does not hit material, another element (probably with larger material volumetric fraction and thus more probability to be accepted) is sampled. In the new implementation, a new coordinate is sampled in the same mesh element until material is hit.
+
+For proper weight normalization, the original implementation needs additional information about the material volumetric fractions. It is supplied implicitly, while the decay gamma source file contains gamma intensity normalized to material volume. More straightforward way is used in the new implementation, where the values in the decay gamma source file are total intensities in each mesh element and can be directly used to e.g. compute the total gamma intensity (simple sum of all entries) in the region covered by the mesh.
+
+Drawbacks
+-----------
+Rejection of decay gamma source coordinates in void cells can be insufficient in some configurations. Consider a steel pipe filled with water. Steel is highly activated as compared to water. In this configuration, gammas will be emmitted both from the pipe walls (as it should be) and from water (since this is not void region). The latter is wrong (decay gamma is originated from steel, not from water) and can affect local distribution of decay heat and SDDR.

--- a/scripts/inventory_s1.sh
+++ b/scripts/inventory_s1.sh
@@ -30,7 +30,6 @@ if [ ! -d "$wdr" ]; then
 
     # Concatenate parts of the input file
     cat "$scr"/header     \
-        "$scw"/mat.title.$1.$2.$3 \
         "$scw"/mat.content.$1.$2.$3 \
         "$scw"/scenario.$1.$2.$3 > "$wdr"/inventory.i
 fi
@@ -43,7 +42,7 @@ if [ ! -f "$wdr"/inventory.tab4 ]; then
     "$r2s_fispact_exe" inventory > fispact.out  || exit 1
     cd "$org"
 fi    
-mv "$wdr"/inventory.tab4 "$scr"/tab4.$1.$2.$3
+ln -s "$wdr"/inventory.tab4 "$scr"/tab4.$1.$2.$3
 
 
 exit 0

--- a/scripts/inventory_s2.sh
+++ b/scripts/inventory_s2.sh
@@ -9,8 +9,7 @@ scw="$r2s_scratch"/r2s_w                 # Scratch foder, where parts of the inv
 
 rm "$scr"/tab4.$1.$2.$3
 rm -rf "$wdr"
-rm "$scw"/mat.title.$1.$2.$3 \
-   "$scw"/mat.content.$1.$2.$3 \
+rm "$scw"/mat.content.$1.$2.$3 \
    "$scw"/scenario.$1.$2.$3 
 
 


### PR DESCRIPTION
FISPACT does not allow multiple entries of a nuclide in the FUEL keyword. This branch merges all repeating nuclides before writing the FUEL keyword. 

Additionally, some subroutines were placed to other modules, following the module responsibility.
